### PR TITLE
Set GOPATH if not already set

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -3,3 +3,7 @@
 if [ "$GOROOT" = "" ] ; then
     export GOROOT=$ASDF_INSTALL_PATH/go
 fi
+
+if [ "$GOPATH" = "" ] ; then
+    export GOPATH=$ASDF_INSTALL_PATH/packages
+fi


### PR DESCRIPTION
Hello Kenny,
I just installed golang. Had to set GOPATH in `exec-env` to fix errors like below:

```
$ go get github.com/elazarl/goproxy
package github.com/elazarl/goproxy: cannot download, $GOPATH not set. For more details see: go help gopath
```

I'm not sure if this is the right thing to do (new to golang). I just followed conventions I previously used for other plugins (each version has it's packages in it's own install directory). Please do let me know if there is a better way to do this.
