### PR TITLE
armv6l and armv7l support; Fixes for Alpine Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Feel free to create an issue or pull request if you find a bug.
 ## Issues
 
 * Assumes Linux or Mac
-* Assumes x86_64 or 386
+* Assumes x86_64, i386, i686, armv6l or armv7l
 
 ## License
 MIT License

--- a/bin/install
+++ b/bin/install
@@ -9,8 +9,23 @@ install_golang () {
     local tempdir=""
 
     [ "Linux" = "$(uname)" ] && platform="linux" || platform="darwin"
-    [ "x86_64" = "$(uname -m)" ] && arch="amd64" || arch="386"
-    [ "linux" = "${platform}" ] && tempdir=$(mktemp -d asdf-golang.XXXX) || tempdir=$(mktemp -dt asdf-golang)
+    local uname_platform="$(uname)"
+    case "$uname_platform" in
+        Linux) platform="linux";;
+        Darwin) platform="darwin";;
+        *) echo "Platform not supported: $uname_platform" && exit 1
+    esac
+
+    case "$(uname -m)" in
+        amd64) arch="amd64";;
+        i386) arch="386";;
+        i686) arch="386";;
+        armv6l) arch="armv6l";;
+        armv7l) arch="armv6l";;
+        *) echo "Unknown architecture: $(uname -m)" && exit 1 
+    esac    
+
+    [ "linux" = "${platform}" ] && tempdir=$(mktemp -d asdf-golang.XXXXXX) || tempdir=$(mktemp -dt asdf-golang)
 
     curl "https://storage.googleapis.com/golang/go${version}.${platform}-${arch}.tar.gz" -o "${tempdir}/archive.tar.gz"
 


### PR DESCRIPTION
This makes go successfully download and install under Alpine Linux running on a Raspberry Pi 2.

However, it is a pain to actually get the binary builds running on Alpine. You have to basically install glibc along side musl.
Quick guide how to break your Alpine system: Copy /lib/ld-linux-armhf.so.3, /lib/libpthread.so.0 and /lib/libc.so.6 from a glibc-based system such as some Gentoo builds. Luckily, they don't clash with the musl stuff.  Go runs, but things linking to libc/other libs will not work correctly.
After it is installed and actually runs, you can recompile Go easily and it'll all be fine and dandy.

In any case, this should make the Raspberry Pi and the Raspberry Pi 2 install golang successfully and make it run, too, under Raspbian, without those evil hacks.