### PR TITLE
Adding a Requirements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 # asdf-golang
 golang plugin for [asdf version manager](https://github.com/asdf-vm/asdf)
 
+
+## Requirements
+**Ubuntu 16.04+** `curl`   
+
+
 ## Install
 
 ```


### PR DESCRIPTION
Adds a requirements section. Ubuntu 16.04 no longer uses curl by default. Could switch to wget?

Coming from: https://github.com/asdf-vm/asdf/pull/295