### PR TITLE
Sort versions so newest version be listed last

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -64,4 +64,5 @@ echo ${VERSIONS[@]} \
     | mysed 's/^go([^.]*).([^.]*).([^.]*).*/\1.\2.\3/' \
     | mysed 's/.(linux|darwin|freebsd|src).*$//' \
     | uniq \
+    | sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n \
     | tr '\n' ' '


### PR DESCRIPTION
The list-all command shows golang versions in the wrong order:
version 1.10 is listed before 1.2 and should be after 1.9 so it
appears closer to the user's prompt.

Since the versions from the website is not in the correct order
a sort is necessary as suggested from [bin/list-all](https://github.com/asdf-vm/asdf/blob/master/docs/creating-plugins.md#binlist-all).
Using an [alternate sort function](https://github.com/vic/asdf-idris/blob/master/bin/list-all#L6) that works on OSX].

Before:
```text
1.10.1
1.10.2
1.10.3
1.10
1.10beta1
1.10beta2
1.10rc1
1.10rc2
1.11beta1
1.2.2
1.3.1
1.3.2
1.3.3
1.3
1.3beta1
1.3beta2
1.3rc1
1.3rc2
1.4.1
1.4.2
1.4.3
1.4
1.4beta1
1.4rc1
1.4rc2
1.5.1
1.5.2
1.5.3
1.5.4
1.5
1.5beta1
1.5beta2
1.5beta3
1.5rc1
1.6.1
1.6.2
1.6.3
1.6.4
1.6
1.6beta1
1.6beta2
1.6rc1
1.6rc2
1.7.1
1.7.2
1.7.3
1.7.4
1.7.5
1.7.6
1.7
1.7beta1
1.7beta2
1.7rc1
1.7rc2
1.7rc3
1.7rc4
1.7rc5
1.7rc6
1.8.1
1.8.2
1.8.3
1.8.4
1.8.5
1.8.5rc4
1.8.6
1.8.7
1.8
1.8beta1
1.8beta2
1.8rc1
1.8rc2
1.8rc3
1.9.1
1.9.2
1.9.2rc2
1.9.3
1.9.4
1.9.5
1.9.6
1.9.7
1.9
1.9beta1
1.9beta2
1.9rc1
1.9rc2
```

After:

```text
1.2.2
1.3
1.3beta1
1.3beta2
1.3rc1
1.3rc2
1.3.1
1.3.2
1.3.3
1.4
1.4beta1
1.4rc1
1.4rc2
1.4.1
1.4.2
1.4.3
1.5
1.5beta1
1.5beta2
1.5beta3
1.5rc1
1.5.1
1.5.2
1.5.3
1.5.4
1.6
1.6beta1
1.6beta2
1.6rc1
1.6rc2
1.6.1
1.6.2
1.6.3
1.6.4
1.7
1.7beta1
1.7beta2
1.7rc1
1.7rc2
1.7rc3
1.7rc4
1.7rc5
1.7rc6
1.7.1
1.7.2
1.7.3
1.7.4
1.7.5
1.7.6
1.8
1.8beta1
1.8beta2
1.8rc1
1.8rc2
1.8rc3
1.8.1
1.8.2
1.8.3
1.8.4
1.8.5
1.8.5rc4
1.8.6
1.8.7
1.9
1.9beta1
1.9beta2
1.9rc1
1.9rc2
1.9.1
1.9.2
1.9.2rc2
1.9.3
1.9.4
1.9.5
1.9.6
1.9.7
1.10
1.10beta1
1.10beta2
1.10rc1
1.10rc2
1.10.1
1.10.2
1.10.3
1.11beta1
```