### PR TITLE
Support ppc64le architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: c
-script: asdf plugin-test golang .
+script: asdf plugin test golang . --asdf-plugin-gitref $TRAVIS_BRANCH go version
 before_script:
+  - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install -y bsdmainutils; fi
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh
-os:
-  - linux
-  - osx
+matrix:
+  include:
+   - os: linux
+     arch: amd64
+   - os: linux
+     arch: ppc64le
+   - os: linux
+     arch: arm64     
+   - os: osx
+     arch: amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-script: asdf plugin test golang . --asdf-plugin-gitref $TRAVIS_BRANCH go version
+script: asdf plugin test golang . --asdf-plugin-gitref $TRAVIS_COMMIT go version
 before_script:
   - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install -y bsdmainutils; fi
   - git clone https://github.com/asdf-vm/asdf.git

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Feel free to create an issue or pull request if you find a bug.
 ## Issues
 
 * Assumes Linux, FreeBSD, or Mac
-* Assumes x86_64, i386, i686, armv6l, armv7l or arm64
+* Assumes x86_64, i386, i686, armv6l, armv7l, arm64 and ppc64le
 
 ## License
 MIT License

--- a/bin/install
+++ b/bin/install
@@ -26,6 +26,7 @@ get_arch () {
         i686|i386) arch="386"; ;;
         armv6l|armv7l) arch="armv6l"; ;;
         aarch64) arch="arm64"; ;;
+        ppc64le) arch="ppc64le"; ;;
         *)
             echo "Arch '$(uname -m)' not supported!" >&2
             exit 1


### PR DESCRIPTION
## Context

Golang offers ppc64le variant however this plugin does not support this platform.

For your information, here is my box spec:

```
$ uname -mr
5.4.12-200.fc31.ppc64le ppc64le # running RaptorCS Blackbird motherboard with IBM Power9 v2 8-core

$ asdf --version
v0.7.6-6207e42
```

## How to reproduce the issue?

```
$ asdf install golang 1.13.6
Platform 'linux' supported!

Arch 'ppc64le' not supported!
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   199  100   199    0     0    293      0 --:--:-- --:--:-- --:--:--   293

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

## Verification

I confirm that this patch allow me to install the ppc64le version successfully.

```
$ go version
go version go1.13.6 linux/ppc64le
```