### PR TITLE
Able to specify an alternative url to install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -2,6 +2,9 @@
 set -eu
 [ "${BASH_VERSINFO[0]}" -ge 3 ] && set -o pipefail
 
+BASE_URL="${BASE_URL:-https://storage.googleapis.com/golang}"
+BASE_URL="${BASE_URL%/}"
+
 get_platform () {
     local platform="$(uname | tr '[:upper:]' '[:lower:]')"
 
@@ -54,7 +57,7 @@ install_golang () {
     local arch=$(get_arch)
     local tempdir=$(my_mktemp $platform)
 
-    curl "https://storage.googleapis.com/golang/go${version}.${platform}-${arch}.tar.gz" -o "${tempdir}/archive.tar.gz"
+    curl "$BASE_URL/go${version}.${platform}-${arch}.tar.gz" -o "${tempdir}/archive.tar.gz"
 
     tar -C "$install_path" -xzf "${tempdir}/archive.tar.gz"
 

--- a/bin/install
+++ b/bin/install
@@ -2,7 +2,7 @@
 set -eu
 [ "${BASH_VERSINFO[0]}" -ge 3 ] && set -o pipefail
 
-BASE_URL="${BASE_URL:-https://storage.googleapis.com/golang}"
+BASE_URL="${BASE_URL:-https://dl.google.com/go}"
 BASE_URL="${BASE_URL%/}"
 
 get_platform () {

--- a/bin/install
+++ b/bin/install
@@ -2,9 +2,6 @@
 set -eu
 [ "${BASH_VERSINFO[0]}" -ge 3 ] && set -o pipefail
 
-BASE_URL="${BASE_URL:-https://dl.google.com/go}"
-BASE_URL="${BASE_URL%/}"
-
 get_platform () {
     local platform="$(uname | tr '[:upper:]' '[:lower:]')"
 
@@ -57,7 +54,7 @@ install_golang () {
     local arch=$(get_arch)
     local tempdir=$(my_mktemp $platform)
 
-    curl "$BASE_URL/go${version}.${platform}-${arch}.tar.gz" -o "${tempdir}/archive.tar.gz"
+    curl "https://dl.google.com/go/go${version}.${platform}-${arch}.tar.gz" -o "${tempdir}/archive.tar.gz"
 
     tar -C "$install_path" -xzf "${tempdir}/archive.tar.gz"
 


### PR DESCRIPTION
For China users, sometimes the download speed from `https://storage.googleapis.com/golang` is really slow, but this one `https://dl.google.com/go` is always faster. After using dig, it shows `dl.google.com` is resolved to a server in Bejing, China. `storage.googleapis.com` is resolved to a server in the USA.

So this PR introduces a shell environment variable `BASE_URL`, so that users can specify an alternative base url to download the tarball.