### PR TITLE
Find the most recent matching installed version

### DIFF
--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -15,7 +15,7 @@ get_legacy_version() {
     GOLANG_VERSION=$(cat "$current_file")
   fi
 
-  echo $(asdf list golang | grep $GOLANG_VERSION | sort -V | tail -1)
+  echo $(asdf list golang | sed -e 's/ //g' | grep "^$GOLANG_VERSION" | sort -V | tail -1)
 }
 
 get_legacy_version "$1"

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -15,7 +15,7 @@ get_legacy_version() {
     GOLANG_VERSION=$(cat "$current_file")
   fi
 
-  echo "$GOLANG_VERSION"
+  echo $(asdf list golang | grep $GOLANG_VERSION | sort -V | tail -1)
 }
 
 get_legacy_version "$1"


### PR DESCRIPTION
This updates the legacy file detection to find the most recent matching installed version of go. So for example if go.mod has `1.13` listed, and your system has `1.13.11` installed then the script will return `1.13.11` instead of `1.13`. 

Tested on Mac and Linux.

Fixes #33 