### PR TITLE
fix: invalid asdf path in `install_default_golang_pkgs()`

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -84,7 +84,7 @@ install_default_go_pkgs() {
     fi
   done
   if [[ $needs_reshim -eq 1 ]]; then
-    "$ASDF_INSTALL_PATH/bin/asdf" reshim golang
+    asdf reshim golang
   fi
 }
 

--- a/bin/install
+++ b/bin/install
@@ -66,8 +66,6 @@ install_default_go_pkgs() {
 
   if [ ! -f $default_go_pkgs ]; then return; fi
 
-  needs_reshim=0
-
   cat "$default_go_pkgs" | while read -r line; do
     name=$(echo "$line" | \
       sed 's|\(.*\) //.*$|\1|' | \
@@ -77,15 +75,11 @@ install_default_go_pkgs() {
     echo -ne "\nInstalling \033[33m${name}\033[39m go pkg... "
     PATH="$ASDF_INSTALL_PATH/bin:$PATH" go get -u $name > /dev/null && rc=$? || rc=$?
     if [[ $rc -eq 0 ]]; then
-      needs_reshim=1
       echo -e "\033[32mSUCCESS\033[39m"
     else
       echo -e "\033[31mFAIL\033[39m"
     fi
   done
-  if [[ $needs_reshim -eq 1 ]]; then
-    asdf reshim golang
-  fi
 }
 
 install_golang $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH


### PR DESCRIPTION
Found `install_default_golang_pkgs()` performs `$ASDF_INSTALL_PATH/bin/asdf reshim`. `$ASDF_INSTALL_PATH` points directory where the specific version should be installed, so `asdf` should not be there.

Also, found that current asdf performs reshim for version of package (i.e. `asdf reshim <name> <version>` ) when plugin's `bin/install` returns success.
https://github.com/asdf-vm/asdf/blob/master/lib/commands/command-install.bash
