### PR TITLE
Support M1 ARM chip

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -25,7 +25,7 @@ get_arch () {
         x86_64|amd64) arch="amd64"; ;;
         i686|i386) arch="386"; ;;
         armv6l|armv7l) arch="armv6l"; ;;
-        aarch64) arch="arm64"; ;;
+        aarch64|arm64) arch="arm64"; ;;
         ppc64le) arch="ppc64le"; ;;
         *)
             echo "Arch '$(uname -m)' not supported!" >&2


### PR DESCRIPTION
Fix error `Arch 'arm64' not supported!` during install on M1 ARM chip.

Note: since Go hasn't added proper support for macOS ARM the installation will still fail. Once support is added by Go maintainers, then this plugin should work, assuming the same download link format is used.

See: https://github.com/golang/go/issues/38485