### PR TITLE
Set default GOPATH and GOROOT when installing default go pkgs

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -67,12 +67,6 @@ install_default_go_pkgs() {
   if [ ! -f $default_go_pkgs ]; then return; fi
 
   needs_reshim=0
-  if [ "$GOROOT" = "" ] ; then
-    export GOROOT="$ASDF_INSTALL_PATH/go"
-  fi
-  if [ "$GOPATH" = "" ]; then
-    export GOPATH="$ASDF_INSTALL_PATH/packages"
-  fi
 
   cat "$default_go_pkgs" | while read -r line; do
     name=$(echo "$line" | \
@@ -81,7 +75,8 @@ install_default_go_pkgs() {
 
     if [ -z $name ]; then continue ; fi
     echo -ne "\nInstalling \033[33m${name}\033[39m go pkg... "
-    PATH="$ASDF_INSTALL_PATH/go/bin:$PATH" go get -u $name > /dev/null && rc=$? || rc=$?
+    GOROOT="$ASDF_INSTALL_PATH/go" GOPATH="$ASDF_INSTALL_PATH/packages" \
+      PATH="$ASDF_INSTALL_PATH/go/bin:$PATH" go get -u $name > /dev/null && rc=$? || rc=$?
     if [[ $rc -eq 0 ]]; then
       echo -e "\033[32mSUCCESS\033[39m"
     else

--- a/bin/install
+++ b/bin/install
@@ -66,8 +66,6 @@ install_default_go_pkgs() {
 
   if [ ! -f $default_go_pkgs ]; then return; fi
 
-  needs_reshim=0
-
   cat "$default_go_pkgs" | while read -r line; do
     name=$(echo "$line" | \
       sed 's|\(.*\) //.*$|\1|' | \

--- a/bin/install
+++ b/bin/install
@@ -68,10 +68,10 @@ install_default_go_pkgs() {
 
   needs_reshim=0
   if [ "$GOROOT" = "" ] ; then
-    export GOROOT=$ASDF_INSTALL_PATH/go
+    export GOROOT="$ASDF_INSTALL_PATH/go"
   fi
   if [ "$GOPATH" = "" ]; then
-    export GOPATH=$ASDF_INSTALL_PATH/packages
+    export GOPATH="$ASDF_INSTALL_PATH/packages"
   fi
 
   cat "$default_go_pkgs" | while read -r line; do

--- a/bin/install
+++ b/bin/install
@@ -67,6 +67,12 @@ install_default_go_pkgs() {
   if [ ! -f $default_go_pkgs ]; then return; fi
 
   needs_reshim=0
+  if [ "$GOROOT" = "" ] ; then
+    export GOROOT=$ASDF_INSTALL_PATH/go
+  fi
+  if [ "$GOPATH" = "" ]; then
+    export GOPATH=$ASDF_INSTALL_PATH/packages
+  fi
 
   cat "$default_go_pkgs" | while read -r line; do
     name=$(echo "$line" | \
@@ -75,7 +81,7 @@ install_default_go_pkgs() {
 
     if [ -z $name ]; then continue ; fi
     echo -ne "\nInstalling \033[33m${name}\033[39m go pkg... "
-    PATH="$ASDF_INSTALL_PATH/bin:$PATH" go get -u $name > /dev/null && rc=$? || rc=$?
+    PATH="$ASDF_INSTALL_PATH/go/bin:$PATH" go get -u $name > /dev/null && rc=$? || rc=$?
     if [[ $rc -eq 0 ]]; then
       needs_reshim=1
       echo -e "\033[32mSUCCESS\033[39m"


### PR DESCRIPTION
Default golang packages listed in `~/.default-golang-pkgs` will be installed unexpected directory when performing `asdf install golang <ver>` without setting `GOPATH` and `GOROOT`.

With changes in this PR, default golang packages should be installed under `$ASDF_INSTALL_PATH/packages` that is default `GOPATH` set in `bin/exec-env`.