### PR TITLE
Add `bin/download` per latest asdf guidelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
   - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install -y bsdmainutils; fi
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh
-  - wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv
+  - wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv
   - cp "shellcheck-stable/shellcheck" /usr/bin
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-language: c
+language: bash
 script: 
   - asdf plugin test golang $TRAVIS_BUILD_DIR --asdf-plugin-gitref $TRAVIS_COMMIT go version
-  - bash -c "shopt -s globstar nullglob; shellcheck $TRAVIS_BUILD_DIR/bin/*"
+  - shellcheck "$TRAVIS_BUILD_DIR/bin"/*
 before_script:
   - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install -y bsdmainutils; fi
   - git clone https://github.com/asdf-vm/asdf.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 script: 
   - asdf plugin test golang $TRAVIS_BUILD_DIR --asdf-plugin-gitref $TRAVIS_COMMIT go version
-  - bash -c 'shopt -s globstar nullglob; shellcheck **/*.{sh,ksh,bash}'
+  - bash -c "shopt -s globstar nullglob; shellcheck $TRAVIS_BUILD_DIR/bin/*"
 before_script:
   - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install -y bsdmainutils; fi
   - git clone https://github.com/asdf-vm/asdf.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
-script: asdf plugin test golang $TRAVIS_BUILD_DIR --asdf-plugin-gitref $TRAVIS_COMMIT go version
+script: 
+  - asdf plugin test golang $TRAVIS_BUILD_DIR --asdf-plugin-gitref $TRAVIS_COMMIT go version
+  - bash -c 'shopt -s globstar nullglob; shellcheck **/*.{sh,ksh,bash}'
 before_script:
   - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install -y bsdmainutils; fi
   - git clone https://github.com/asdf-vm/asdf.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: bash
 script: 
   - asdf plugin test golang $TRAVIS_BUILD_DIR --asdf-plugin-gitref $TRAVIS_COMMIT go version
-  - shellcheck "$TRAVIS_BUILD_DIR/bin"/*
+  - "$TRAVIS_BUILD_DIR/shellcheck" "$TRAVIS_BUILD_DIR/bin"/*
 before_script:
   - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install -y bsdmainutils; fi
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh
   - wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv
-  - cp "shellcheck-stable/shellcheck" /usr/bin
+  - cp "shellcheck-stable/shellcheck" "$TRAVIS_BUILD_DIR/shellcheck"
 matrix:
   include:
    - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: bash
 script: 
   - asdf plugin test golang $TRAVIS_BUILD_DIR --asdf-plugin-gitref $TRAVIS_COMMIT go version
-  - "$TRAVIS_BUILD_DIR/shellcheck" "$TRAVIS_BUILD_DIR/bin"/*
 before_script:
   - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install -y bsdmainutils; fi
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh
-  - wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv
-  - cp "shellcheck-stable/shellcheck" "$TRAVIS_BUILD_DIR/shellcheck"
 matrix:
   include:
    - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ before_script:
   - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install -y bsdmainutils; fi
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh
+  - wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv
+  - cp "shellcheck-stable/shellcheck" /usr/bin
 matrix:
   include:
    - os: linux

--- a/bin/download
+++ b/bin/download
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -eu
+[ "${BASH_VERSINFO[0]}" -ge 3 ] && set -o pipefail
+
+get_platform () {
+    local platform=""
+    
+    platform="$(uname | tr '[:upper:]' '[:lower:]')"
+
+    case "$platform" in
+        linux|darwin|freebsd)
+            echo "Platform '${platform}' supported!" >&2
+            ;;
+        *)
+            echo "Platform '${platform}' not supported!" >&2
+            exit 1
+            ;;
+    esac
+
+    echo -n "$platform"
+}
+
+get_arch () {
+    local arch=""
+
+    case "$(uname -m)" in
+        x86_64|amd64) arch="amd64"; ;;
+        i686|i386) arch="386"; ;;
+        armv6l|armv7l) arch="armv6l"; ;;
+        aarch64|arm64) arch="arm64"; ;;
+        ppc64le) arch="ppc64le"; ;;
+        *)
+            echo "Arch '$(uname -m)' not supported!" >&2
+            exit 1
+            ;;
+    esac
+
+    echo -n $arch
+}
+
+download_golang () {
+    local version=$1
+    local download_path=$2
+    local platform=""
+    local arch=""
+
+    platform=$(get_platform)
+    arch=$(get_arch)
+
+    curl "https://dl.google.com/go/go${version}.${platform}-${arch}.tar.gz" -o "${download_path}/archive.tar.gz"
+}
+
+download_golang "$ASDF_INSTALL_VERSION" "$ASDF_DOWNLOAD_PATH"

--- a/bin/download
+++ b/bin/download
@@ -2,23 +2,10 @@
 set -eu
 [ "${BASH_VERSINFO[0]}" -ge 3 ] && set -o pipefail
 
-get_platform () {
-    local platform=""
+PLUGIN_DIR="$(dirname "${BASH_SOURCE[0]}")/.."
 
-    platform="$(uname | tr '[:upper:]' '[:lower:]')"
-
-    case "$platform" in
-        linux|darwin|freebsd)
-            echo "Platform '${platform}' supported!" >&2
-            ;;
-        *)
-            echo "Platform '${platform}' not supported!" >&2
-            exit 1
-            ;;
-    esac
-
-    echo -n "$platform"
-}
+# shellcheck source=/dev/null
+source "$PLUGIN_DIR/lib/helpers.sh"
 
 get_arch () {
     local arch=""
@@ -30,8 +17,7 @@ get_arch () {
         aarch64|arm64) arch="arm64"; ;;
         ppc64le) arch="ppc64le"; ;;
         *)
-            echo "Arch '$(uname -m)' not supported!" >&2
-            exit 1
+            fail "Arch '$(uname -m)' not supported!"
             ;;
     esac
 
@@ -53,8 +39,7 @@ check_shasum() {
         -a 256 \
         -c <<<"$authentic_checksum $archive_file_name"
     else
-        echo "sha256sum or shasum is not available for use" >&2
-        return 1
+        fail "sha256sum or shasum is not available for use"
     fi
 }
 
@@ -72,10 +57,9 @@ download_golang () {
 
     echo 'verifying checksum'
     if ! check_shasum "${download_path}/archive.tar.gz" "${download_path}/archive.tar.gz.sha256"; then
-        echo "\033[31mAuthenticity of package archive can not be assured. Exiting.\033[39m" >&2
-        exit 1
+        fail "Authenticity of package archive can not be assured. Exiting."
     else
-      echo -e "\033[32mcheckum verified\033[39m" >&2
+      msg "checksum verified"
     fi
 }
 

--- a/bin/download
+++ b/bin/download
@@ -4,7 +4,7 @@ set -eu
 
 get_platform () {
     local platform=""
-    
+
     platform="$(uname | tr '[:upper:]' '[:lower:]')"
 
     case "$platform" in

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -4,7 +4,7 @@ if [ "${ASDF_INSTALL_VERSION}" != 'system' ] ; then
 	if [ "$GOROOT" = "" ] ; then
 	    export GOROOT=$ASDF_INSTALL_PATH/go
 	fi
-	
+
 	if [ "$GOPATH" = "" ] ; then
 	    export GOPATH=$ASDF_INSTALL_PATH/packages
 	fi

--- a/bin/install
+++ b/bin/install
@@ -2,10 +2,15 @@
 set -eu
 [ "${BASH_VERSINFO[0]}" -ge 3 ] && set -o pipefail
 
+PLUGIN_DIR="$(dirname "${BASH_SOURCE[0]}")/.."
+
+# shellcheck source=/dev/null
+source "$PLUGIN_DIR/lib/helpers.sh"
+
 my_mktemp () {
     local tempdir=""
     local platform=""
-    platform="$(uname | tr '[:upper:]' '[:lower:]')"
+    platform="$(get_platform)"
 
     if [ "linux" = "$platform" ] ; then
         tempdir=$(mktemp -d asdf-golang.XXXX)
@@ -23,7 +28,7 @@ install_golang () {
 
     if [ -z "$download_path" ] ; then
         download_path="$(my_mktemp)"
-        ASDF_INSTALL_VERSION="$version" ASDF_DOWNLOAD_PATH="$download_path" "$(dirname "${BASH_SOURCE[0]}")/download"
+        ASDF_INSTALL_VERSION="$version" ASDF_DOWNLOAD_PATH="$download_path" "$PLUGIN_DIR/bin/download"
     fi
 
     tar -C "$install_path" -xzf "${download_path}/archive.tar.gz"
@@ -50,9 +55,9 @@ install_default_go_pkgs() {
         go get -u "$name" > /dev/null && rc=$? || rc=$?
 
     if [[ $rc -eq 0 ]]; then
-      echo -e "\033[32mSUCCESS\033[39m" >&2
+      msg "SUCCESS"
     else
-      echo -e "\033[31mFAIL\033[39m" >&2
+      err "FAIL"
     fi
   done < "$default_go_pkgs"
 }

--- a/bin/install
+++ b/bin/install
@@ -23,7 +23,7 @@ install_golang () {
 
     if [ -z "$download_path" ] ; then
         download_path="$(my_mktemp)"
-        env - ASDF_INSTALL_VERSION="$version" ASDF_DOWNLOAD_PATH="$download_path" "$(dirname "${BASH_SOURCE[0]}")/download"
+        ASDF_INSTALL_VERSION="$version" ASDF_DOWNLOAD_PATH="$download_path" "$(dirname "${BASH_SOURCE[0]}")/download"
     fi
 
     tar -C "$install_path" -xzf "${download_path}/archive.tar.gz"
@@ -44,8 +44,10 @@ install_default_go_pkgs() {
     if [ -z "$name" ]; then continue ; fi
 
     echo -ne "\nInstalling \033[33m${name}\033[39m go pkg... " >&2
-    env - GOROOT="$ASDF_INSTALL_PATH/go" GOPATH="$ASDF_INSTALL_PATH/packages" \
-        PATH="$go_path:$PATH" go get -u "$name" > /dev/null && rc=$? || rc=$?
+    GOROOT="$ASDF_INSTALL_PATH/go" \
+        GOPATH="$ASDF_INSTALL_PATH/packages" \
+        PATH="$go_path:$PATH" \
+        go get -u "$name" > /dev/null && rc=$? || rc=$?
 
     if [[ $rc -eq 0 ]]; then
       echo -e "\033[32mSUCCESS\033[39m" >&2

--- a/bin/install
+++ b/bin/install
@@ -2,91 +2,65 @@
 set -eu
 [ "${BASH_VERSINFO[0]}" -ge 3 ] && set -o pipefail
 
-get_platform () {
-    local platform="$(uname | tr '[:upper:]' '[:lower:]')"
-
-    case "$platform" in
-        linux|darwin|freebsd)
-            echo "Platform '${platform}' supported!" >&2
-            ;;
-        *)
-            echo "Platform '${platform}' not supported!" >&2
-            exit 1
-            ;;
-    esac
-
-    echo -n $platform
-}
-
-get_arch () {
-    local arch=""
-
-    case "$(uname -m)" in
-        x86_64|amd64) arch="amd64"; ;;
-        i686|i386) arch="386"; ;;
-        armv6l|armv7l) arch="armv6l"; ;;
-        aarch64|arm64) arch="arm64"; ;;
-        ppc64le) arch="ppc64le"; ;;
-        *)
-            echo "Arch '$(uname -m)' not supported!" >&2
-            exit 1
-            ;;
-    esac
-
-    echo -n $arch
-}
-
 my_mktemp () {
     local tempdir=""
-    if [ "linux" = "$1" ] ; then
+    local platform=""
+    platform="$(uname | tr '[:upper:]' '[:lower:]')"
+
+    if [ "linux" = "$platform" ] ; then
         tempdir=$(mktemp -d asdf-golang.XXXX)
     else
         tempdir=$(mktemp -dt asdf-golang.XXXX)
     fi
-    echo -n $tempdir
+
+    echo -n "$tempdir"
 }
 
 install_golang () {
-    local install_type=$1
-    local version=$2
-    local install_path=$3
-    local platform=$(get_platform)
-    local arch=$(get_arch)
-    local tempdir=$(my_mktemp $platform)
+    local version="$1"
+    local download_path="$2"
+    local install_path="$3"
 
-    curl "https://dl.google.com/go/go${version}.${platform}-${arch}.tar.gz" -o "${tempdir}/archive.tar.gz"
+    if [ -z "$download_path" ] ; then
+        download_path="$(my_mktemp)"
+        env - ASDF_INSTALL_VERSION="$version" ASDF_DOWNLOAD_PATH="$download_path" "$(dirname "${BASH_SOURCE[0]}")/download"
+    fi
 
-    tar -C "$install_path" -xzf "${tempdir}/archive.tar.gz"
-
-    rm -rf "${tempdir}"
+    tar -C "$install_path" -xzf "${download_path}/archive.tar.gz"
 }
 
 install_default_go_pkgs() {
+  local go_path="$1/go/bin"
+  local asdf_bin="$1/bin/asdf"
   local default_go_pkgs="${HOME}/.default-golang-pkgs"
 
-  if [ ! -f $default_go_pkgs ]; then return; fi
+  if [ ! -f "$default_go_pkgs" ]; then return; fi
 
   needs_reshim=0
 
-  cat "$default_go_pkgs" | while read -r line; do
+  while read -r line; do
     name=$(echo "$line" | \
       sed 's|\(.*\) //.*$|\1|' | \
       sed -E 's|^[[:space:]]*//.*||') # the first sed is for comments after package names, the second for full line comments
 
-    if [ -z $name ]; then continue ; fi
+    # Skip empty lines
+    if [ -z "$name" ]; then continue ; fi
+
     echo -ne "\nInstalling \033[33m${name}\033[39m go pkg... "
-    PATH="$ASDF_INSTALL_PATH/go/bin:$PATH" go get -u $name > /dev/null && rc=$? || rc=$?
+    env - PATH="$go_path:$PATH" go get -u "$name" > /dev/null && rc=$? || rc=$?
+
     if [[ $rc -eq 0 ]]; then
       needs_reshim=1
       echo -e "\033[32mSUCCESS\033[39m"
     else
       echo -e "\033[31mFAIL\033[39m"
     fi
-  done
+  done < "$default_go_pkgs"
+
   if [[ $needs_reshim -eq 1 ]]; then
-    "$ASDF_INSTALL_PATH/bin/asdf" reshim golang
+    "$asdf_bin" reshim golang
   fi
 }
 
-install_golang $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
-install_default_go_pkgs
+install_golang "$ASDF_INSTALL_VERSION" "$ASDF_DOWNLOAD_PATH" "$ASDF_INSTALL_PATH"
+install_default_go_pkgs "$ASDF_INSTALL_PATH"

--- a/bin/list-all
+++ b/bin/list-all
@@ -11,10 +11,9 @@ TRUNCATED='true'
 # Shamelessly stolen from: https://stackoverflow.com/questions/893585/how-to-parse-xml-in-bash {
 function read_dom() {
     local IFS=\>
-    read -d \< ENTITY CONTENT
+    read -rd \< ENTITY CONTENT
     local RET=$?
     TAG_NAME=${ENTITY%% *}
-    ATTRIBUTES=${ENTITY#* }
     return $RET
 }
 
@@ -31,11 +30,11 @@ function parse_dom() {
 }
 
 function get_versions() {
-  XML=$(curl --silent ${BASE_URL}${NEXT_MARKER})
+  XML=$(curl --silent "${BASE_URL}${NEXT_MARKER}")
 
   while read_dom; do
       parse_dom
-  done <<< $XML
+  done <<< "$XML"
 }
 # }
 
@@ -48,15 +47,15 @@ function loop_versions() {
 
 mysed () {
     if [ "$(uname | tr '[:upper:]' '[:lower:]' | sed -E 's/(darwin|freebsd)/HERE/')" = "HERE" ] ; then
-      sed -Ee $1
+      sed -Ee "$1"
     else
-      sed -re $1
+      sed -re "$1"
     fi
 }
 
 loop_versions
 
-echo ${VERSIONS[@]} \
+echo "${VERSIONS[@]}" \
     | tr ' ' '\n' \
     | grep '.tar.gz' \
     | grep '\(linux\|darwin\|freebsd\)' \

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -15,7 +15,7 @@ get_legacy_version() {
     GOLANG_VERSION=$(cat "$current_file")
   fi
 
-  echo $(asdf list golang | sed -e 's/ //g' | grep "^$GOLANG_VERSION" | sort -V | tail -1)
+  asdf list golang | sed -e 's/ //g' | grep "^$GOLANG_VERSION" | sort -V | tail -1
 }
 
 get_legacy_version "$1"

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -eu
+[ "${BASH_VERSINFO[0]}" -ge 3 ] && set -o pipefail
+
+get_platform () {
+    local platform=""
+
+    platform="$(uname | tr '[:upper:]' '[:lower:]')"
+
+    case "$platform" in
+        linux|darwin|freebsd)
+            msg "Platform '${platform}' supported!"
+            ;;
+        *)
+            fail "Platform '${platform}' not supported!"
+            ;;
+    esac
+
+    echo -n "$platform"
+}
+
+msg () {
+    echo -e "\033[32m$1\033[39m" >&2
+}
+
+err () {
+    echo -e "\033[31m$1\033[39m" >&2
+}
+
+fail () {
+    err "$1"
+    exit 1
+}


### PR DESCRIPTION
Summary
-------------
- Creates a temporary directory if using an older version of asdf.
- Install delegates to `bin/download` if using an older version of asdf.

Notes
--------
`bin/download` description: https://github.com/asdf-vm/asdf/blob/master/docs/plugins-create.md#bindownload