### PR TITLE
Add extra space between shasum args

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -37,7 +37,7 @@ check_shasum() {
     elif command -v shasum >/dev/null 2>&1; then
         shasum \
         -a 256 \
-        -c <<<"$authentic_checksum $archive_file_name"
+        -c <<<"$authentic_checksum  $archive_file_name"
     else
         fail "sha256sum or shasum is not available for use"
     fi


### PR DESCRIPTION
Hi, have been having a weird problem on macOS Big Sur:

```
verifying checksum
shasum: standard input: no properly formatted SHA checksum lines found
Authenticity of package archive can not be assured. Exiting.
```

I've seen varying [re](https://unix.stackexchange.com/a/561549)fe[re](https://thomask.sdf.org/blog/2019/05/05/techniques-for-verifying-shasums-conveniently.html#md5sumsha1sumsha256sum-coreutils:~:text=You%20have%20to%20type%20all%20this,like%20them.%20Very%20interesting%20history%20though.)nc[es](https://github.com/docker-library/memcached/pull/6/files) to this error online but no clear explanation as to what's going on. The solution seems to be to have two spaces between the `shasum` arguments. The reason this might be passing still in travis builds is that travis appears to be using an older version of macOS with an older version of `shasum`.

I tried this fix in my fork of the plugin and it worked. Opening to see if someone more linux savvy can explain what's going on.