### PR TITLE
Use highest matching minor version from go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ github.com/Dreamacro/clash
 github.com/jesseduffield/lazygit
 ```
 
+## Version selection
+
+When using `.tool-versions` or `.go-version`, the exact version specified in the
+file will be selected.
+
+When using `go.mod`, the highest compatible version that is currently installed
+will be selected. As per the [Go modules
+reference](https://golang.org/ref/mod#go-mod-file-go), that is the highest minor
+version with a matching major version. For example, a `go 1.14` directive in a
+`go.mod` file will result in the highest installed `1.minor.patch` being
+selected, not necessarily `1.14.patch`.
+
 ## Contributing
 
 Feel free to create an issue or pull request if you find a bug.

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -6,9 +6,10 @@ get_legacy_version() {
 
   if [ "$basename" == "go.mod" ]; then
     GOLANG_VERSION=$(grep 'go\s*[0-9]' "$current_file" |
-                       sed -e 's/.*heroku goVersion //' \
+                       sed -E \
+                           -e 's/.*heroku goVersion //' \
                            -e 's/[[:space:]]//' \
-                           -e 's/go\(.*\)/\1/' |
+                           -e 's/go([0-9]+).*/\1/' |
                        head -1
       )
   else


### PR DESCRIPTION
The go directive in go.mod files is of the format `major.minor`. This
commit will allow the highest installed version of go with the same
major component to be selected. The previous behaviour was to use the
highest installed version with the same major _and_ minor components,
but I don't think this was strictly necessary. It is valid to use go
1.16 to build a project whose go.mod declares "go 1.14", for example.
For packages within the module, the compiler should reject use of
language features introduced after the version specified by the go
directive.

I think this adheres more closely to the expected behaviour of programs
that parse `go.mod`, and asdf users who need to pin a particular minor
or patch version of go can use `.tool-versions` or `.go-version`.

Source: https://golang.org/ref/mod#go-mod-file-go