### PR TITLE
Add extra space between sha256sum args

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -33,7 +33,7 @@ check_shasum() {
 
     if command -v sha256sum >/dev/null 2>&1; then
         sha256sum \
-            -c <<<"$authentic_checksum $archive_file_name"
+            -c <<<"$authentic_checksum  $archive_file_name"
     elif command -v shasum >/dev/null 2>&1; then
         shasum \
         -a 256 \


### PR DESCRIPTION
This PR adds one extra space for `sha256sum`. If this space is lacking, Alpine Linux `sha256sum` cannot work properly (also see https://github.com/gliderlabs/docker-alpine/issues/174): 

```
[hyperion@wizard test]$ sha256sum -c <<< "951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2 go.tar.gz"
sha256sum: WARNING: 1 of 1 computed checksums did NOT match
[hyperion@wizard test]$ sha256sum -c <<< "951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2  go.tar.gz"
go.tar.gz: OK
```

but in the coreutils version an extra space doesn't break anything:

```
sam@wizard:/tmp % sha256sum --version
sha256sum (GNU coreutils) 8.32
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Ulrich Drepper, Scott Miller, and David Madore.
sam@wizard:/tmp % sha256sum -c <<< "951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2 go.tar.gz"
go.tar.gz: OK
sam@wizard:/tmp % sha256sum -c <<< "951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2  go.tar.gz"
go.tar.gz: OK
```