### PR TITLE
fail when download status 404 or 403

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -51,9 +51,15 @@ download_golang () {
 
     platform=$(get_platform)
     arch=$(get_arch)
+    download_url="https://dl.google.com/go/go${version}.${platform}-${arch}.tar.gz"
 
-    curl "https://dl.google.com/go/go${version}.${platform}-${arch}.tar.gz" -o "${download_path}/archive.tar.gz"
-    curl "https://dl.google.com/go/go${version}.${platform}-${arch}.tar.gz.sha256" -o "${download_path}/archive.tar.gz.sha256"
+    http_code=$(curl -I -w %{http_code} -s -o /dev/null $download_url)
+    if [ $http_code -eq 404 ] || [ $http_code -eq 403 ]; then
+        fail "URL: ${download_url} returned status ${http_code}"
+    fi
+
+    curl $download_url -o "${download_path}/archive.tar.gz"
+    curl "${download_url}.sha256" -o "${download_path}/archive.tar.gz.sha256"
 
     echo 'verifying checksum'
     if ! check_shasum "${download_path}/archive.tar.gz" "${download_path}/archive.tar.gz.sha256"; then


### PR DESCRIPTION
Hi! Thanks for your useful tools.

Try to download golang 1.15, which does not support m1 mac, output is the following.

```shell
$ asdf install golang 1.15.13
mkdir: /Users/w1mvy/.asdf/downloads/golang/1.15.13: File exists
Platform 'darwin' supported!
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1449  100  1449    0     0   7173      0 --:--:-- --:--:-- --:--:--  7173
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1449  100  1449    0     0   5138      0 --:--:-- --:--:-- --:--:--  5138
verifying checksum
sha256sum: 'standard input': no properly formatted SHA256 checksum lines found
Authenticity of package archive can not be assured. Exiting.
tar: Error opening archive: Unrecognized archive format
```

When the http status of the download source is 404 / 403, output error message for clarity.
