### PR TITLE
Document ASDF_GOLANG_DEFAULT_PACKAGES_FILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ github.com/Dreamacro/clash
 github.com/jesseduffield/lazygit
 ```
 
+You can specify a non-default location of this file by setting a `ASDF_GOLANG_DEFAULT_PACKAGES_FILE` variable.
+
 ## Version selection
 
 When using `.tool-versions` or `.go-version`, the exact version specified in the


### PR DESCRIPTION
This patch adds documentation for the ASDF_GOLANG_DEFAULT_PACKAGES_FILE variable introduced in #59 (I neglected to include this there—sorry about that).

