### PR TITLE
Fix missing minor version when parsing go.mod

### DIFF
--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -9,7 +9,7 @@ get_legacy_version() {
                        sed -E \
                            -e 's/.*heroku goVersion //' \
                            -e 's/[[:space:]]//' \
-                           -e 's/go([0-9]+).*/\1/' |
+                           -e 's/go([0-9]+.*)/\1/' |
                        head -1
       )
   else


### PR DESCRIPTION
The minor version was missing since the group in the last regexp
captured only digits.

Closes #65.
