### PR TITLE
Updated the default packages command to use "go install" for versions 1.16+

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -29,7 +29,10 @@ install_golang () {
 install_default_go_pkgs() {
   local go_path="$1/go/bin"
   local default_go_pkgs="${ASDF_GOLANG_DEFAULT_PACKAGES_FILE:-${HOME}/.default-golang-pkgs}"
-  local go_version=`${2} | cut -d. -f2`
+  go_minor_version=$(${2} | cut -d. -f2)
+  go_major_version=$(${2} | cut -d. -f1)
+  local go_major_version = go_major_version
+  local go_minor_version = go_minor_version
 
   if [ ! -f "$default_go_pkgs" ]; then return; fi
 
@@ -45,7 +48,7 @@ install_default_go_pkgs() {
     echo -ne "\nInstalling \033[33m${name}\033[39m go pkg... " >&2
 
     # if using go > 1.16 then use go install as the preferred donwload path
-    if [ $go_version -ge 16 ]; then
+    if [ "$go_major_version" -ge 2 ] || [ "$go_minor_version" -ge 16 ]; then
         GOROOT="$ASDF_INSTALL_PATH/go" \
             GOPATH="$ASDF_INSTALL_PATH/packages" \
             PATH="$go_path:$PATH" \

--- a/bin/install
+++ b/bin/install
@@ -29,10 +29,7 @@ install_golang () {
 install_default_go_pkgs() {
   local go_path="$1/go/bin"
   local default_go_pkgs="${ASDF_GOLANG_DEFAULT_PACKAGES_FILE:-${HOME}/.default-golang-pkgs}"
-  go_minor_version=$(${2} | cut -d. -f2)
-  go_major_version=$(${2} | cut -d. -f1)
-  local go_major_version = go_major_version
-  local go_minor_version = go_minor_version
+  IFS=. read -r go_major_version go_minor_version <<<"${2}"
 
   if [ ! -f "$default_go_pkgs" ]; then return; fi
 
@@ -48,7 +45,7 @@ install_default_go_pkgs() {
     echo -ne "\nInstalling \033[33m${name}\033[39m go pkg... " >&2
 
     # if using go > 1.16 then use go install as the preferred donwload path
-    if [ "$go_major_version" -ge 2 ] || [ "$go_minor_version" -ge 16 ]; then
+    if [ "$go_major_version" -ge 2 ] || [ "${go_minor_version//[!0-9]*}" -ge 16 ]; then
         GOROOT="$ASDF_INSTALL_PATH/go" \
             GOPATH="$ASDF_INSTALL_PATH/packages" \
             PATH="$go_path:$PATH" \

--- a/bin/install
+++ b/bin/install
@@ -20,7 +20,7 @@ install_golang () {
     fi
 
     tar -C "$install_path" -xzf "${download_path}/archive.tar.gz"
-    
+
     if [ "1" = "$created_tmp" ]; then
         rm -r "$download_path"
     fi
@@ -29,8 +29,10 @@ install_golang () {
 install_default_go_pkgs() {
   local go_path="$1/go/bin"
   local default_go_pkgs="${ASDF_GOLANG_DEFAULT_PACKAGES_FILE:-${HOME}/.default-golang-pkgs}"
+  local go_version=`${2} | cut -d. -f2`
 
   if [ ! -f "$default_go_pkgs" ]; then return; fi
+
 
   while read -r line; do
     name=$(echo "$line" | \
@@ -41,10 +43,19 @@ install_default_go_pkgs() {
     if [ -z "$name" ]; then continue ; fi
 
     echo -ne "\nInstalling \033[33m${name}\033[39m go pkg... " >&2
-    GOROOT="$ASDF_INSTALL_PATH/go" \
-        GOPATH="$ASDF_INSTALL_PATH/packages" \
-        PATH="$go_path:$PATH" \
-        go get -u "$name" > /dev/null && rc=$? || rc=$?
+
+    # if using go > 1.16 then use go install as the preferred donwload path
+    if [ $go_version -ge 16 ]; then
+        GOROOT="$ASDF_INSTALL_PATH/go" \
+            GOPATH="$ASDF_INSTALL_PATH/packages" \
+            PATH="$go_path:$PATH" \
+            go install "$name" > /dev/null && rc=$? || rc=$?
+    else
+        GOROOT="$ASDF_INSTALL_PATH/go" \
+            GOPATH="$ASDF_INSTALL_PATH/packages" \
+            PATH="$go_path:$PATH" \
+            go get -u "$name" > /dev/null && rc=$? || rc=$?
+    fi
 
     if [[ $rc -eq 0 ]]; then
       msg "SUCCESS"
@@ -55,4 +66,4 @@ install_default_go_pkgs() {
 }
 
 install_golang "$ASDF_INSTALL_VERSION" "${ASDF_DOWNLOAD_PATH:-}" "$ASDF_INSTALL_PATH"
-install_default_go_pkgs "$ASDF_INSTALL_PATH"
+install_default_go_pkgs "$ASDF_INSTALL_PATH" "$ASDF_INSTALL_VERSION"


### PR DESCRIPTION
Like the title suggests, this should update the default packages command to use `go install` for go versions 1.16 and higher as it is now the command to be used when downloading a module to be run as a binary: https://go.dev/blog/go116-module-changes

The `go_version` variable _should_ be set correctly, I assumed the `"$ASDF_INSTALL_VERSION"` variable was in the form of `X.X.X` without any other parts to it, if that's incorrect let me know and I can update it