### PR TITLE
Don't compare extracted version with list of currently installed versions

### DIFF
--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -5,18 +5,15 @@ get_legacy_version() {
   basename=$(basename -- "$current_file")
 
   if [ "$basename" == "go.mod" ]; then
-    GOLANG_VERSION=$(grep 'go\s*[0-9]' "$current_file" |
-                       sed -E \
-                           -e 's/.*heroku goVersion //' \
-                           -e 's/[[:space:]]//' \
-                           -e 's/go([0-9]+).*/\1/' |
-                       head -1
-      )
+    grep 'go\s*[0-9]' "$current_file" |
+      sed -E \
+          -e 's/.*heroku goVersion //' \
+          -e 's/[[:space:]]//' \
+          -e 's/go//' |
+      head -1
   else
-    GOLANG_VERSION=$(cat "$current_file")
+    cat "$current_file"
   fi
-
-  asdf list golang | sed -e 's/ //g' | grep "^$GOLANG_VERSION" | sort -V | tail -1
 }
 
 get_legacy_version "$1"

--- a/tests/parse-legacy-file_test.sh
+++ b/tests/parse-legacy-file_test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(realpath "$0" | xargs dirname | xargs dirname)"
+PARSE_LEGACY_FILE="${REPO_ROOT}/bin/parse-legacy-file"
+
+parse_legacy_file_test::assert() {
+  local testname actual expected result
+  testname="$1"
+  actual="$2"
+  expected="$3"
+
+  if [[ "${actual}" != "${expected}" ]]; then
+    result=failed
+  else
+    result=passed
+  fi
+
+  echo "${result}: ${testname}: expected '${expected}', got '${actual}'"
+}
+
+parse_legacy_file_test::test_valid_go_mod() {
+  local tmpdir expected actual result
+  tmpdir="$(mktemp -d)"
+  expected=1.17.2
+
+  echo "go ${expected}" > "${tmpdir}/go.mod"
+  actual="$("${PARSE_LEGACY_FILE}" "${tmpdir}/go.mod")"
+
+  parse_legacy_file_test::assert "${FUNCNAME[0]}" "${actual}" "${expected}"
+}
+
+parse_legacy_file_test::test_valid_go_mod_heroku() {
+  local tmpdir expected actual result
+  tmpdir="$(mktemp -d)"
+  expected=1.11
+
+  cat <<EOF > "${tmpdir}/go.mod"
+// +heroku goVersion go${expected}
+// this line, and the one below, should effectively be ignored.
+go 1.0.0 
+
+EOF
+  actual="$("${PARSE_LEGACY_FILE}" "${tmpdir}/go.mod")"
+
+  parse_legacy_file_test::assert "${FUNCNAME[0]}" "${actual}" "${expected}"
+}
+
+parse_legacy_file_test::test_valid_go_version() {
+  local tmpdir expected actual result
+  tmpdir="$(mktemp -d)"
+  expected=1.12
+
+  echo "${expected}" > "${tmpdir}/.go-version"
+  actual="$("${PARSE_LEGACY_FILE}" "${tmpdir}/.go-version")"
+
+  parse_legacy_file_test::assert "${FUNCNAME[0]}" "${actual}" "${expected}"
+}
+
+parse_legacy_file_test::main() {
+  parse_legacy_file_test::test_valid_go_mod
+  parse_legacy_file_test::test_valid_go_mod_heroku
+  parse_legacy_file_test::test_valid_go_version
+}
+
+parse_legacy_file_test::main


### PR DESCRIPTION
# background

I installed this plugin and tried using it to install a golang version. I had no existing golang installations. Here's a reproducible illustration of what happens:

```sh-session
[~/code/go-test]
# ls -la
total 0
drwxr-xr-x  2 me  64 Feb 18 14:16 .
drwxr-xr-x 17 me 544 Feb 18 14:05 ..

[~/code/go-test]
# cat ~/.asdfrc
legacy_version_file = yes

[~/code/go-test]
# echo 'go 1.17.2' > go.mod

[~/code/go-test]
# asdf install golang
  No versions installed
No versions specified for golang in config files or environment

[~/code/go-test]
# asdf list golang
  No versions installed
```

note that `asdf install golang` shows the same stderr output at `asdf list golang`. 

# analysis

turns out, that's because `parse-legacy-file` invokes `asdf list golang` in order to compare the go version it extracts to that list of versions.

this is a problem for me, because I don't have any golang versions installed; even if I did, the behavior seems incorrect, as it seems to require that a version to be installed already is installed.

# solution

I opted to nix that whole `asdf list golang` pipeline, and simplify the sed command that strips `go` from the version string.

I've also provided some basic tests to validate the behavior before and after making changes to the script.