### PR TITLE
Make exec-env strict-mode compliant

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 if [ "${ASDF_INSTALL_VERSION}" != 'system' ] ; then
-	if [ "$GOROOT" = "" ] ; then
+	if [[ "unset" == "${GOROOT:-unset}" ]] ; then
 	    export GOROOT=$ASDF_INSTALL_PATH/go
 	fi
 
-	if [ "$GOPATH" = "" ] ; then
+	if [[ "unset" == "${GOPATH:-unset}" ]] ; then
 	    export GOPATH=$ASDF_INSTALL_PATH/packages
 	fi
 fi


### PR DESCRIPTION
This file is not strict-mode compliant and because of that, if you execute it from a script in strict mode, it will throw an error like follows:

```bash
WARN Failed to discover go env: failed to run 'go env': exit status 1
ERRO Running error: context loading failed: failed to load packages: failed to load with go/packages: err: exit status 1: stderr: /Users/myuser/.asdf/plugins/golang/bin/exec-env: line 4: GOROOT: unbound variable
```