### PR TITLE
Handle unset GOROOT/GOPATH with bash nounset

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-if [ "${ASDF_INSTALL_VERSION}" != 'system' ] ; then
-	if [ "$GOROOT" = "" ] ; then
-	    export GOROOT=$ASDF_INSTALL_PATH/go
+if [ "${ASDF_INSTALL_VERSION}" != 'system' ]; then
+	if [ "${GOROOT:-''}" = "" ]; then
+		export GOROOT=$ASDF_INSTALL_PATH/go
 	fi
 
-	if [ "$GOPATH" = "" ] ; then
-	    export GOPATH=$ASDF_INSTALL_PATH/packages
+	if [ "${GOPATH:-''}" = "" ]; then
+		export GOPATH=$ASDF_INSTALL_PATH/packages
 	fi
 fi


### PR DESCRIPTION
Without this change, as soon as I install a non-system golang,
`exec-env` gives me errors like this:

```
direnv: using asdf golang 1.18.3
direnv: loading ~/.asdf/plugins/golang/bin/exec-env
./exec-env:4: GOROOT: unbound variable
```
