### PR TITLE
Use process substitution to adapt FreeBSD's sha256sum

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -16,11 +16,11 @@ check_shasum() {
 
     if command -v sha256sum >/dev/null 2>&1; then
         sha256sum \
-            -c <<<"$authentic_checksum  $archive_file_name"
+            -c <(echo "$authentic_checksum  $archive_file_name")
     elif command -v shasum >/dev/null 2>&1; then
         shasum \
         -a 256 \
-        -c <<<"$authentic_checksum  $archive_file_name"
+        -c <(echo "$authentic_checksum  $archive_file_name")
     else
         fail "sha256sum or shasum is not available for use"
     fi


### PR DESCRIPTION
Hi, I tried to use asdf-golang for my FreeBSD to run into error:

(with `set -x`)

```
devbsd% asdf install  golang  latest          
mkdir: /home/windymelt/.asdf/downloads/golang/1.19: File exists
Platform 'freebsd' supported!
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  141M  100  141M    0     0  10.3M      0  0:00:13  0:00:13 --:--:-- 10.6M
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    64  100    64    0     0    240      0 --:--:-- --:--:-- --:--:--   241
verifying checksum
+ local archive_file_name=/home/windymelt/.asdf/downloads/golang/1.19/archive.tar.gz
+ local authentic_checksum_file=/home/windymelt/.asdf/downloads/golang/1.19/archive.tar.gz.sha256
+ local authentic_checksum=
+ authentic_checksum=eca1a8f7b6ff6146efc285eed581096b12b59c1f0488bfe98ed053ab205267ca
+ command -v sha256sum
+ sha256sum -c
sha256sum: option requires an argument -- c
usage: sha256sum [-pqrtx] [-c file] [-s string] [files ...]
+ fail 'Authenticity of package archive can not be assured. Exiting.'
+ err 'Authenticity of package archive can not be assured. Exiting.'
+ echo -e '\033[31mAuthenticity of package archive can not be assured. Exiting.\033[39m'
Authenticity of package archive can not be assured. Exiting.
+ exit 1
```

Then I found `sha256sum` installed in FreeBSD 13.1 has no support for reading integrity list file from STDIN (omitting value for `-c` option causes error).

Fortunately, bash supports process substitution. Using `<(echo "blah blah")` can be used as replacement of STDIN:

```shell
% sha256sum -c <<< "blah blah" # does not work...
% sha256sum -c <(echo "blah blah") # it works!!!
```

Would you mind to merge this pr to polish up FreeBSD support?