### PR TITLE
Add support for msys2 on windows

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -31,21 +31,25 @@ download_golang () {
     local download_path=$2
     local platform=""
     local arch=""
+    local filetype="tar.gz"
 
     platform=$(get_platform)
+    if [ "$platform" == "windows" ]; then
+        filetype="zip"
+    fi
     arch=$(get_arch)
-    download_url="https://dl.google.com/go/go${version}.${platform}-${arch}.tar.gz"
+    download_url="https://dl.google.com/go/go${version}.${platform}-${arch}.${filetype}"
 
     http_code=$(curl -I -w '%{http_code}' -s -o /dev/null "$download_url")
     if [ "$http_code" -eq 404 ] || [ "$http_code" -eq 403 ]; then
         fail "URL: ${download_url} returned status ${http_code}"
     fi
 
-    curl "$download_url" -o "${download_path}/archive.tar.gz"
-    curl "${download_url}.sha256" -o "${download_path}/archive.tar.gz.sha256"
+    curl "$download_url" -o "${download_path}/archive.${filetype}"
+    curl "${download_url}.sha256" -o "${download_path}/archive.${filetype}.sha256"
 
     echo 'verifying checksum'
-    if ! check_shasum "${download_path}/archive.tar.gz" "${download_path}/archive.tar.gz.sha256"; then
+    if ! check_shasum "${download_path}/archive.${filetype}" "${download_path}/archive.${filetype}.sha256"; then
         fail "Authenticity of package archive can not be assured. Exiting."
     else
       msg "checksum verified"

--- a/bin/install
+++ b/bin/install
@@ -18,8 +18,12 @@ install_golang () {
         created_tmp="1"
         ASDF_INSTALL_VERSION="$version" ASDF_DOWNLOAD_PATH="$download_path" "$PLUGIN_DIR/bin/download"
     fi
-
-    tar -C "$install_path" -xzf "${download_path}/archive.tar.gz"
+   
+    if [ "$(get_platform)" == "windows" ]; then
+        unzip -d "$install_path" "${download_path}/archive.zip"
+    else
+        tar -C "$install_path" -xzf "${download_path}/archive.tar.gz"
+    fi
 
     if [ "1" = "$created_tmp" ]; then
         rm -r "$download_path"

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -9,6 +9,10 @@ get_platform () {
     platform="$(uname | tr '[:upper:]' '[:lower:]')"
 
     case "$platform" in
+        msys_nt*)
+	    platform="windows"
+            [ -z "$silent" ] && msg "Platform '${platform}' supported!"
+            ;;
         linux|darwin|freebsd)
             [ -z "$silent" ] && msg "Platform '${platform}' supported!"
             ;;


### PR DESCRIPTION
This adds windows support when using the [msys2](https://www.msys2.org/)  bash and linux tooling.