### PR TITLE
Don't call back into `asdf list golang`

### DIFF
--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -1,5 +1,29 @@
 #!/usr/bin/env bash
 
+plugin_dir() {
+    local current_script_path=${BASH_SOURCE[0]}
+    cd "$(dirname "$(dirname "$current_script_path")")" || exit
+    pwd
+}
+
+install_dir() {
+  printf -v pdir "%s" "$(plugin_dir)"
+  printf -v plugin_name "%s" "$(basename "$pdir")"
+  printf "%s/installs/%s" "$(dirname "$(dirname "$pdir")")" "$plugin_name"
+}
+
+installed_versions() {
+  local plugin_installs_path
+  plugin_installs_path="$(install_dir)"
+
+  if [ -d "$plugin_installs_path" ]; then
+    for install in "${plugin_installs_path}"/*/; do
+      [[ -e "$install" ]] || break
+      basename "$install" | sed 's/^ref-/ref:/'
+    done
+  fi
+}
+
 get_legacy_version() {
   current_file="$1"
   basename=$(basename -- "$current_file")
@@ -12,11 +36,20 @@ get_legacy_version() {
                            -e 's/go([0-9]+).*/\1/' |
                        head -1
       )
-  else
+  elif [ -e "$current_file" ]; then
     GOLANG_VERSION=$(cat "$current_file")
+  else
+    GOLANG_VERSION=""
   fi
 
-  asdf list golang | sed -e 's/ //g' | grep "^$GOLANG_VERSION" | sort -V | tail -1
+  local installed
+  installed=$(installed_versions | sed -e 's/ //g' | grep "^$GOLANG_VERSION" | sort -V | tail -1)
+
+  if [ -z "$installed" ]; then
+    installed=$("$(plugin_dir)/bin/latest-stable" "$GOLANG_VERSION")
+  fi
+
+  echo "$installed"
 }
 
 get_legacy_version "$1"


### PR DESCRIPTION
asdf v0.11.0 introduced a change that causes and infinate recurse when calling `asdf list golang` from `parse-legacy-file` as noted in issue #83 and [asdf/1372](https://github.com/asdf-vm/asdf/issues/1372).

This fixes #83.