### PR TITLE
Add support for ASDF_GOLANG_MOD_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ version with a matching major version. For example, a `go 1.14` directive in a
 selected, not necessarily `1.14.patch`.
 
 **Note**: Users can explicitly exclude or include `go.mod` and `go.work` by
-setting `ASDF_GOLANG_MOD_VERSION`. Currently it defaults to `true`, but that
+setting `ASDF_GOLANG_MOD_VERSION_ENABLED`. Currently it defaults to `true`, but that
 may change in the future, so it should be explicitly set.
 
 ## Architecture Override

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ version with a matching major version. For example, a `go 1.14` directive in a
 `go.mod` file will result in the highest installed `1.minor.patch` being
 selected, not necessarily `1.14.patch`.
 
+**Note**: Users can explicitly exclude or include `go.mod` and `go.work` by
+setting `ASDF_GOLANG_MOD_VERSION`. Currently it defaults to `true`, but that
+may change in the future, so it should be explicitly set.
+
 ## Architecture Override
 
 The `ASDF_GOLANG_OVERWRITE_ARCH` variable can be used to override the architecture 

--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-case "${ASDF_GOLANG_MOD_VERSION:-}" in
+case "${ASDF_GOLANG_MOD_VERSION_ENABLED:-}" in
 	true)
 		printf ".go-version go.mod go.work\n"
 		;;
@@ -9,7 +9,7 @@ case "${ASDF_GOLANG_MOD_VERSION:-}" in
 		;;
 	*)
 		cat >&2 <<-EOF
-		Notice: Behaving like ASDF_GOLANG_MOD_VERSION=true
+		Notice: Behaving like ASDF_GOLANG_MOD_VERSION_ENABLED=true
 		        In the future this will have to be set to continue
 		        reading from the go.mod and go.work files
 		EOF

--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -1,3 +1,18 @@
 #!/usr/bin/env bash
 
-echo ".go-version go.mod go.work"
+case "${ASDF_GOLANG_MOD_VERSION:-}" in
+	true)
+		printf ".go-version go.mod go.work\n"
+		;;
+	false)
+		printf ".go-version\n"
+		;;
+	*)
+		cat >&2 <<-EOF
+		Notice: Behaving like ASDF_GOLANG_MOD_VERSION=true
+		        In the future this will have to be set to continue
+		        reading from the go.mod and go.work files
+		EOF
+		printf ".go-version go.mod go.work\n"
+		;;
+esac


### PR DESCRIPTION
## Description

This changes the behavior of `bin/list-legacy-file` to allow users to set `ASDF_GOLANG_MOD_VERSION` to determine the inclusion of `go.mod` and `go.work`. As discussed in #99 upstream `asdf` has determined that the current behavior is not desirable, so we are starting down the path of deprecation.