### PR TITLE
Use built-in zsh function to get absolute dir path for golang

### DIFF
--- a/set-env.zsh
+++ b/set-env.zsh
@@ -1,15 +1,9 @@
-function absolute_dir_path {
-    local absolute_path
-    absolute_path="$( cd -P "$( dirname "$1" )" && pwd )"
-    echo "$absolute_path"
-}
-
 asdf_update_golang_env() {
   local go_path
   go_path="$(asdf which go)"
   if [[ -n "${go_path}" ]]; then
     export GOROOT
-    GOROOT="$(dirname "$(absolute_dir_path "${go_path}")")"   
+    GOROOT="$(dirname "$(dirname "${go_path:A}")")"
   fi
 }
 


### PR DESCRIPTION
Hello, I've recently started using this project in combination with direnv and noticed a small improvement. What's happening is the following

1. I **cd** into a directory with a .envrc file
2. Any command that's executed within this directory will always trigger an **direnv: unloading** hook

After some research, I found that this issue was related to **set-env.zsh** and the use of **absolute_dir_path**. In fact, I found a similar issue which was resolved:
https://github.com/halcyon/asdf-java/pull/144

In summary, the fix uses zsh's built in functionality to get the absolute dir path. This makes **absolute_dir_path** obsolete 🙂.
