### PR TITLE
Better: Add netbsd support.

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -21,8 +21,11 @@ check_shasum() {
     shasum \
       -a 256 \
       -c <(echo "$authentic_checksum  $archive_file_name")
+  elif command -v sha256 >/dev/null 2>&1; then
+    sha256 \
+      -c <(echo "SHA256 ($archive_file_name) = $authentic_checksum")
   else
-    fail "sha256sum or shasum is not available for use"
+    fail "no shasum tool available, supported: sha256sum, shasum or sha256"
   fi
 }
 

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -9,7 +9,7 @@ get_platform() {
   platform="$(uname | tr '[:upper:]' '[:lower:]')"
 
   case "$platform" in
-    linux | darwin | freebsd)
+    linux | darwin | freebsd | netbsd)
       [ -z "$silent" ] && msg "Platform '${platform}' supported!"
       ;;
     *)


### PR DESCRIPTION
Before:

```sh
netbsd$ cat .tool-versions 
golang 1.23.11
netbsd$ asdf install
Platform 'netbsd' not supported!
failed to run download callback: exit status 1
```

After:

```sh
netbsd$ cat .tool-versions 
golang 1.23.11
netbsd$ asdf install
Platform 'netbsd' supported!
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 69.8M  100 69.8M    0     0  17.2M      0  0:00:04  0:00:04 --:--:-- 17.2M
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    64  100    64    0     0    821      0 --:--:-- --:--:-- --:--:--   831
verifying checksum
checksum verified
netbsd$ asdf list golang
 *1.23.11
netbsd$ go version
go version go1.23.11 netbsd/amd64
```