### PR TITLE
fix: refactor package parsing and fix command execution

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -34,12 +34,14 @@ install_default_go_pkgs() {
   if [ ! -f "$default_go_pkgs" ]; then return; fi
 
   while read -r line; do
-    name=$(echo "$line" |
-      sed 's|\(.*\) //.*$|\1|' |
-      sed -E 's|^[[:space:]]*//.*||') # the first sed is for comments after package names, the second for full line comments
+    # Skip empty lines and comments
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*// ]] && continue
 
-    # Skip empty lines
-    if [ -z "$name" ]; then continue; fi
+    # Remove inline comments and trim whitespace
+    name=$(echo "$line" | sed 's|//.*||' | xargs)
+
+    # Skip if empty after processing
+    [ -z "$name" ] && continue
 
     echo -ne "\nInstalling \033[33m${name}\033[39m go pkg... " >&2
 


### PR DESCRIPTION
**Problem:**
- Package installation failed with "invalid char ' '" errors due to improper whitespace handling
- Complex sed regex patterns were fragile and hard to maintain
- Duplicated environment setup code for go install vs go get

**Solution:**
- Simplified comment parsing using bash pattern matching for full-line comments
- Added explicit whitespace trimming with xargs after removing inline comments
- Consolidated go command execution using array for proper argument handling
- Use separate variable for package installation to avoid mutating display name

**Changes:**
- Replace complex sed patterns with simpler, more robust parsing logic
- Use bash array for go_cmd to properly handle "get -u" as separate arguments
- Add stderr redirection (2>&1) for proper error capture
- Fix typo: "donwload" -> "download"
- Consolidate duplicate GOROOT/GOPATH/PATH setup

**Impact:**
- Fixes installation failures for packages in .default-golang-pkgs
- Supports comments and various whitespace formatting in package files
- More maintainable code
- Closes #163 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `bin/install` to robustly parse default package entries and unify `go install/get` execution with shared env and proper argument handling.
> 
> - **bin/install**:
>   - **Package parsing**: Skip empty/comment lines via bash pattern; strip inline comments and trim whitespace; avoid mutating display name.
>   - **Command execution**: Use `go_cmd` array and `pkg_to_install` (append `@latest` when needed); consolidate env setup and invoke `go` once; redirect stdout/stderr to `/dev/null 2>&1`.
>   - **Go version handling**: Retain `install` for >=1.16, `get -u` otherwise using array args.
>   - **Misc**: Fix typo "donwload" -> "download".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e164f0fa85851e921fde3085997d884d5ae61f93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->