### PR TITLE
fix: use hooks in nushell set-env script to properly set GO variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ To ensure the Golang environment variables are correctly set when using the `asd
   source (echo $ASDF_DATA_DIR | if test -z $it; echo $HOME/.asdf; else echo $it; end)/plugins/golang/set-env.fish
   ```
 
-- **Nushell (`env.nu`):**
+- **Nushell (`config.nu`):**
 
   ```nu
-  source (if ($env.ASDF_DATA_DIR | empty?) { echo $nu.env.HOME/.asdf } { echo $env.ASDF_DATA_DIR })/plugins/golang/set-env.nu
+  const asdf_data_dir = '~/.asdf' | path expand # this variable should be already set in your configuration as it is used to configure asdf itself
+  source ([$asdf_data_dir plugins golang set-env.nu] | path join)
   ```
 
 ## When using `go get` or `go install`

--- a/set-env.nu
+++ b/set-env.nu
@@ -1,1 +1,17 @@
-$env.GOROOT = (asdf which go | path split | drop 2 | path join)
+def --env asdf-update-golang-env [] {
+  let go_path = asdf which go | complete
+  if $go_path.exit_code == 0 {
+    let root = ($go_path.stdout | str trim | path split | drop 2 | path join)
+    if $root != $env.GOROOT? {
+      $env.GOROOT = $root
+      $env.GOPATH = ($root | path dirname | path join packages)
+      $env.GOBIN = ($root | path dirname | path join bin)
+    }
+  }
+}
+
+asdf-update-golang-env
+
+$env.config.hooks.env_change.PWD = (
+  $env.config.hooks.env_change | get -o PWD | default [] | append {|| asdf-update-golang-env }
+)


### PR DESCRIPTION
The Nushell set-env script currently runs once at shell startup but doesn't update GOROOT, GOPATH, and GOBIN when changing directories.

This means moving into a project with a different Go version in .tool-versions causes errors like:
`compile: version "go1.21.13" does not match go tool version "go1.25.4"`

The proposed fix follows the pattern already used by the Fish set-env script: wrap the env setup in a function and register it as a PWD change hook, so the Go variables stay in sync as you navigate between projects.

Happy to hear any feedback or alternative approaches - first PR here, so suggestions are very welcome!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Nushell Go env so `GOROOT`, `GOPATH`, and `GOBIN` update on directory changes. Prevents Go version mismatch errors when switching between projects.

- **Bug Fixes**
  - Move env setup into `asdf-update-golang-env` and register it on `$env.config.hooks.env_change.PWD`.
  - Derive `GOROOT` from `asdf which go`; set `GOPATH` and `GOBIN` relative to it; run once at startup and on PWD changes.
  - Update README: source from `config.nu` and use `$asdf_data_dir` when loading `set-env.nu`.

<sup>Written for commit b0e32046121459d8aaf0952624d90c0bb64a12ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/asdf-community/asdf-golang/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

