### PR TITLE
fix(nushell): automatically refresh env variables using hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ To ensure the Golang environment variables are correctly set when using the `asd
   source (echo $ASDF_DATA_DIR | if test -z $it; echo $HOME/.asdf; else echo $it; end)/plugins/golang/set-env.fish
   ```
 
-- **Nushell (`env.nu`):**
+- **Nushell (`config.nu`):**
 
   ```nu
-  source (if ($env.ASDF_DATA_DIR | empty?) { echo $nu.env.HOME/.asdf } { echo $env.ASDF_DATA_DIR })/plugins/golang/set-env.nu
+  # ... Required asdf setup ... (see https://asdf-vm.com/guide/getting-started.html#add-shims-directory-to-path-required-5)
+  source ([$asdf_data_dir plugins golang set-env.nu] | path join)
   ```
 
 ## When using `go get` or `go install`

--- a/set-env.nu
+++ b/set-env.nu
@@ -1,1 +1,17 @@
-$env.GOROOT = (asdf which go | path split | drop 2 | path join)
+def --env asdf-update-golang-env [] {
+  let go_path = asdf which go | complete
+  if $go_path.exit_code == 0 {
+    let root = ($go_path.stdout | str trim | path split | drop 2 | path join)
+    if $root != $env.GOROOT? {
+      $env.GOROOT = $root
+      $env.GOPATH = ($root | path dirname | path join packages)
+      $env.GOBIN = ($root | path dirname | path join bin)
+    }
+  }
+}
+
+asdf-update-golang-env
+
+$env.config.hooks.env_change.PWD = (
+  $env.config.hooks.env_change | get -o PWD | default [] | prepend {|| asdf-update-golang-env }
+)

--- a/set-env.nu
+++ b/set-env.nu
@@ -11,6 +11,6 @@ def --env asdf-update-golang-env [] {
 
 asdf-update-golang-env
 
-$env.config.hooks.env_change.PWD = (
-  $env.config.hooks.env_change | get -o PWD | default [] | prepend {|| asdf-update-golang-env }
+$env.config.hooks.pre_prompt = (
+  $env.config.hooks | get -o pre_prompt | default [] | prepend {|| asdf-update-golang-env }
 )

--- a/set-env.nu
+++ b/set-env.nu
@@ -9,8 +9,6 @@ def --env asdf-update-golang-env [] {
   }
 }
 
-asdf-update-golang-env
-
 $env.config.hooks.pre_prompt = (
   $env.config.hooks | get -o pre_prompt | default [] | prepend {|| asdf-update-golang-env }
 )

--- a/set-env.nu
+++ b/set-env.nu
@@ -1,12 +1,11 @@
 def --env asdf-update-golang-env [] {
   let go_path = asdf which go | complete
-  if $go_path.exit_code == 0 {
-    let root = ($go_path.stdout | str trim | path split | drop 2 | path join)
-    if $root != $env.GOROOT? {
-      $env.GOROOT = $root
-      $env.GOPATH = ($root | path dirname | path join packages)
-      $env.GOBIN = ($root | path dirname | path join bin)
-    }
+  if $go_path.exit_code != 0 {return}
+  let root = ($go_path.stdout | str trim | path split | drop 2 | path join)
+  if $root != $env.GOROOT? {
+    $env.GOROOT = $root
+    $env.GOPATH = ($root | path dirname | path join packages)
+    $env.GOBIN = ($root | path dirname | path join bin)
   }
 }
 


### PR DESCRIPTION
## Problem

The current set-env.nu sets GOROOT / GOPATH / GOBIN exactly once, at shell startup. When you cd into a project whose .tool-versions pins a different Go version, the env vars stay pinned to the startup version while the go shim resolves to the project version, producing errors like:

`compile: version "go1.21.13" does not match go tool version "go1.25.4"`

Other shells (bash, zsh, fish) don't have this issue because their integrations re-evaluate on each prompt.

## Proposal

Move the env-setting logic into a function and register it as a PWD env_change hook.  
The function will follow the same logic used for the other shells.

## Sanity check I'd like on this

I hooked into the PWD env_change event, so the GO vars refresh whenever the user steps into a project with its own .tool-versions. This reflects my preferences and has tradeoffs:
- the hook only fires on directory changes, not on every prompt, so there's no needless work in the common case.
- if the user bumps the Go version in an existing .tool-versions without leaving the directory, the env vars go stale.

I'm personally fine with manually refreshing in that rare case, and I'd rather avoid a hook that runs on every prompt, but I recognize that's a matter of preference. We could as well hook into the pre-prompt or pre-execution hooks and cover all cases. Happy to defer to the maintainers here

Love ❤️

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-refresh Go env vars in Nushell at each prompt so they match the project's `asdf`-selected Go version. Fixes version mismatch errors when switching projects or updating `.tool-versions`.

- **Bug Fixes**
  - Added `asdf-update-golang-env`; runs on `pre_prompt` via `$env.config.hooks` (startup call removed).
  - Sets `GOROOT`, `GOPATH`, and `GOBIN` from `asdf which go`; updates only when values change; no-op if `go` isn’t available.
  - Updated README: source `plugins/golang/set-env.nu` from `$asdf_data_dir` in `config.nu` after required `asdf` setup.

<sup>Written for commit b108f0f861d689251a460e81391080749ba6821b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/asdf-community/asdf-golang/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

